### PR TITLE
JSDK-2270: do not customize userAgent from electron tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+npm-debug.log
+package-lock.json

--- a/.release.json
+++ b/.release.json
@@ -1,6 +1,6 @@
 {
   "type": "JavaScript",
-  "travis": true,
+  "travis": false,
   "slug": "twilio/karma-electron.js",
   "env": {
     "GH_REF": "github.com/twilio/karma-electron.js.git"

--- a/.release.json
+++ b/.release.json
@@ -1,0 +1,35 @@
+{
+  "type": "JavaScript",
+  "travis": true,
+  "slug": "twilio/karma-electron.js",
+  "env": {
+    "GH_REF": "github.com/twilio/karma-electron.js.git"
+  },
+  "plans": {
+    "release": {
+      "env": {
+        "GIT_USER_NAME": "twilio-ci",
+        "GIT_USER_EMAIL": "twilio-ci@twilio.com"
+      },
+      "commands": [
+        "node ./node_modules/.bin/release --bump ${CURRENT_VERSION} ${RELEASE_VERSION}",
+        "git config user.name \"${GIT_USER_NAME}\"",
+        "git config user.email \"${GIT_USER_EMAIL}\"",
+        "git add package.json",
+        "git commit -m \"${RELEASE_VERSION}\"",
+        "git tag ${RELEASE_VERSION}",
+        "git remote set-url origin \"https://${GH_TOKEN}@${GH_REF}\"",
+        "git rebase HEAD ${BRANCH}",
+        "git push origin ${BRANCH} --tags"
+      ]
+    },
+    "development": {
+      "commands": [
+        "node ./node_modules/.bin/release --bump ${RELEASE_VERSION} ${DEVELOPMENT_VERSION}",
+        "git add package.json",
+        "git commit -m \"${DEVELOPMENT_VERSION}\"",
+        "git push origin ${BRANCH}"
+      ]
+    }
+  }
+}

--- a/lib/electron-launcher.js
+++ b/lib/electron-launcher.js
@@ -46,14 +46,6 @@ app.on('ready', function handleReady () {
   var browserWindow = new BrowserWindow({
     show: !!program.show
   });
-  browserWindow.loadURL(program.url, {
-    // Set a custom User-Agent for better logging
-    // https://github.com/atom/electron/blob/v0.36.9/docs/api/browser-window.md#winloadurlurl-options
-    // https://github.com/atom/electron/blob/v0.36.9/docs/api/web-contents.md#webcontentsloadurlurl-options
-    // DEV: Default would be "Chrome 47.0.2526 (Linux 0.0.0)"
-    //   https://github.com/karma-runner/karma/blob/v0.13.21/lib/browser.js#L25
-    //   https://github.com/karma-runner/karma/blob/v0.13.21/lib/helper.js#L7-L11
-    // Example: Electron 0.36.9 (Node.js 5.1.1)
-    userAgent: 'Electron ' + process.versions.electron + ' (Node ' + process.versions.node + ')'
-  });
+
+  browserWindow.loadURL(program.url);
 });

--- a/lib/electron-launcher.js
+++ b/lib/electron-launcher.js
@@ -46,6 +46,5 @@ app.on('ready', function handleReady () {
   var browserWindow = new BrowserWindow({
     show: !!program.show
   });
-
   browserWindow.loadURL(program.url);
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "karma-electron",
   "description": "Karma launcher and preprocessor for Electron",
-  "version": "6.0.0",
+  "version": "1.0.0-dev",
   "homepage": "https://github.com/twolfson/karma-electron",
   "author": {
     "name": "Todd Wolfson",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "karma-phantomjs-launcher": "~1.0.0",
     "mocha": "~1.11.0",
     "phantomjs-prebuilt": "~2.1.5",
+    "release-tool": "^0.2.2",
     "request": "~2.72.0",
     "twolfson-style": "~1.6.0"
   },


### PR DESCRIPTION
Electron wraps Chrome, but allows apps to customize its user Agent. Our video SDK makes decision on which code path to take based on user agent values.  Customizing user agent prevents us from telling chrome from Edge and such.  This small change removes the customization of user agent from karma-electron. This will enable us to use this package from https://github.com/twilio/twilio-webrtc.js, for adding integration tests against Electron.

I have verified that with this change (and corresponding change in twilio-webrtc we can run electron tests, There are few more issues with some of the tests running on electron, that need to be fleshed out. But this change is independent and should be good to go. 

and finally Yay, first PR!



